### PR TITLE
feat(serverless): add support for routes prefix

### DIFF
--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -367,7 +367,7 @@ class Provider {
             }; // Signing context token
 
             const newLtik = jwt.sign(newLtikObj, (0, _classPrivateFieldGet2.default)(this, _ENCRYPTIONKEY));
-            return res.redirect(307, (0, _classPrivateFieldGet2.default)(this, _appUrl) + '?ltik=' + newLtik);
+            return res.redirect(307, req.baseUrl + (0, _classPrivateFieldGet2.default)(this, _appUrl) + '?ltik=' + newLtik);
           } else {
             if ((0, _classPrivateFieldGet2.default)(this, _whitelistedUrls).indexOf(req.path) !== -1 || (0, _classPrivateFieldGet2.default)(this, _whitelistedUrls).indexOf(req.path + '-method-' + req.method.toUpperCase()) !== -1) {
               provMainDebug('Accessing as whitelisted URL');
@@ -376,7 +376,7 @@ class Provider {
 
             provMainDebug('No LTIK found');
             provMainDebug('Request body: ', req.body);
-            return res.redirect((0, _classPrivateFieldGet2.default)(this, _invalidTokenUrl));
+            return res.redirect(req.baseUrl + (0, _classPrivateFieldGet2.default)(this, _invalidTokenUrl));
           }
         }
 
@@ -443,7 +443,7 @@ class Provider {
             message: req.body
           });
           provMainDebug('Passing request to session timeout handler');
-          return res.redirect((0, _classPrivateFieldGet2.default)(this, _sessionTimeoutUrl));
+          return res.redirect(req.baseUrl + (0, _classPrivateFieldGet2.default)(this, _sessionTimeoutUrl));
         }
       } catch (err) {
         provAuthDebug(err.message);
@@ -452,7 +452,7 @@ class Provider {
           message: 'Message: ' + err.message + '\nStack: ' + err.stack
         });
         provMainDebug('Passing request to invalid token handler');
-        return res.redirect((0, _classPrivateFieldGet2.default)(this, _invalidTokenUrl));
+        return res.redirect(req.baseUrl + (0, _classPrivateFieldGet2.default)(this, _invalidTokenUrl));
       }
     };
 

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -652,6 +652,18 @@ The default values for these configurations are respectively `3000 and false`.
 
 If set to `true`, the `silent` option supressess the default console logs that occurs during the startup and graceful shutdown routines.
 
+Deploying the application as part of another express application.
+
+```javascript
+const app = express()
+const lti = new LTI('EXAMPLEKEY', { url: 'mongodb://localhost/database' })
+
+// start LTI provider in serverless mode (experimental flag)
+await lti.deploy({serverless: true})
+
+// mount LTI express app into preexisting express app
+app.use('/lti', lti.app)
+```
 
 #### The onConnect() method
 

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -303,7 +303,7 @@ class Provider {
             // Signing context token
             const newLtik = jwt.sign(newLtikObj, this.#ENCRYPTIONKEY)
 
-            return res.redirect(307, this.#appUrl + '?ltik=' + newLtik)
+            return res.redirect(307, req.baseUrl + this.#appUrl + '?ltik=' + newLtik)
           } else {
             if (this.#whitelistedUrls.indexOf(req.path) !== -1 || this.#whitelistedUrls.indexOf(req.path + '-method-' + req.method.toUpperCase()) !== -1) {
               provMainDebug('Accessing as whitelisted URL')
@@ -311,7 +311,7 @@ class Provider {
             }
             provMainDebug('No LTIK found')
             provMainDebug('Request body: ', req.body)
-            return res.redirect(this.#invalidTokenUrl)
+            return res.redirect(req.baseUrl + this.#invalidTokenUrl)
           }
         }
 
@@ -369,13 +369,13 @@ class Provider {
           provMainDebug('Request body: ', req.body)
           if (this.#logger) this.#logger.log({ level: 'error', message: req.body })
           provMainDebug('Passing request to session timeout handler')
-          return res.redirect(this.#sessionTimeoutUrl)
+          return res.redirect(req.baseUrl + this.#sessionTimeoutUrl)
         }
       } catch (err) {
         provAuthDebug(err.message)
         if (this.#logger) this.#logger.log({ level: 'error', message: 'Message: ' + err.message + '\nStack: ' + err.stack })
         provMainDebug('Passing request to invalid token handler')
-        return res.redirect(this.#invalidTokenUrl)
+        return res.redirect(req.baseUrl + this.#invalidTokenUrl)
       }
     }
 


### PR DESCRIPTION
Added the ability to prefix the lti routes.

Added documentation on how to deploy the LTI provider app as a part of another express app.

All tests passed except for two which were nit passing prior to the change.

Any and all feedback is appreciated 