### PR TITLE
Don't log serverless message in silent mode

### DIFF
--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -572,8 +572,11 @@ class Provider {
       if (options && options.silent) conf.silent = options.silent
       // Starts server on given port
 
-      if (options && options.serverless) console.log('Ltijs started in serverless mode...')
-      else {
+      if (options && options.serverless) {
+        if (!conf.silent) {
+          console.log('Ltijs started in serverless mode...')
+        }
+      } else {
         await this.#server.listen(conf.port)
         provMainDebug('Ltijs started listening on port: ', conf.port)
 


### PR DESCRIPTION
When `deploy` is given the `silent` option along with `serverless`, it will still log the message that the server started in serverless mode. I believe we should respect the dev's choice to have this be completely silent