### PR TITLE
Remove trailing space in DeepLinking response errormsg claim field

### DIFF
--- a/src/Provider/Services/DeepLinking.js
+++ b/src/Provider/Services/DeepLinking.js
@@ -81,7 +81,7 @@ class DeepLinking {
     // Adding messaging options
     if (options) {
       if (options.message) jwtBody['https://purl.imsglobal.org/spec/lti-dl/claim/msg'] = options.message
-      if (options.errMessage || options.errmessage) jwtBody['https://purl.imsglobal.org/spec/lti-dl/claim/errormsg '] = options.errMessage || options.errmessage
+      if (options.errMessage || options.errmessage) jwtBody['https://purl.imsglobal.org/spec/lti-dl/claim/errormsg'] = options.errMessage || options.errmessage
       if (options.log) jwtBody['https://purl.imsglobal.org/spec/lti-dl/claim/log'] = options.log
       if (options.errLog || options.errlog) jwtBody['https://purl.imsglobal.org/spec/lti-dl/claim/errorlog'] = options.errLog || options.errlog
     }


### PR DESCRIPTION
This PR removes a trailing space in the `https://purl.imsglobal.org/spec/lti-dl/claim/errormsg` field that's sent as part of the "Deep linking response message".

We discovered an issue with the trailing space in a Blackboard context.

Blackboard does not seem to handle the field correctly as is, showing a generic error message ("The LTI tool reported an error. Please try again or contact your administrator for help") instead of the actual value of the `errormsg` field. Removing the trailing space fixed the issue for us.

![image](https://user-images.githubusercontent.com/12753296/155409882-a196386e-5281-4cd9-a8d4-034e4797f720.png)
 