### PR TITLE
Fix 181: Add context hash to contextId in database

### DIFF
--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -351,26 +351,19 @@ class Provider {
             const resourceId = valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'] ? valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'].id : 'NF';
             const clientId = valid.clientId;
             const deploymentId = valid['https://purl.imsglobal.org/spec/lti/claim/deployment_id'];
-            const contextProperties = {
+            const additionalContextProperties = {
               path: req.path,
-              user: valid.sub,
               roles: valid['https://purl.imsglobal.org/spec/lti/claim/roles'],
               targetLinkUri: valid['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
-              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
-              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
               custom: valid['https://purl.imsglobal.org/spec/lti/claim/custom'],
               launchPresentation: valid['https://purl.imsglobal.org/spec/lti/claim/launch_presentation'],
-              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
-              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
-              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
-              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
               endpoint: valid['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'],
               namesRoles: valid['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']
             };
-            const hashOfContextProperties = crypto.createHash('sha256').update(JSON.stringify(contextProperties)).digest('hex');
+            const hashOfAdditionalContextProperties = crypto.createHash('sha256').update(JSON.stringify(additionalContextProperties)).digest('hex');
 
-            // Appending hashOfContextProperties is a temporary fix to prevent overwriting existing database entries. See: https://github.com/Cvmcosta/ltijs/issues/181 
-            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + "_" + hashOfContextProperties);
+            // Appending hashOfContextProperties is a temporary fix to prevent overwriting existing database entries in some scenarios. See: https://github.com/Cvmcosta/ltijs/issues/181 
+            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + "_" + hashOfAdditionalContextProperties);
             const platformCode = encodeURIComponent('lti' + Buffer.from(valid.iss + clientId + deploymentId).toString('base64'));
 
             // Mount platform token
@@ -400,7 +393,14 @@ class Provider {
             // Mount context token
             const contextToken = {
               contextId,
-              ...contextProperties
+              user: valid.sub,
+              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
+              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
+              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
+              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
+              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
+              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
+              ...additionalContextProperties
             };
 
             // Store contextToken in database

--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -351,7 +351,26 @@ class Provider {
             const resourceId = valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'] ? valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'].id : 'NF';
             const clientId = valid.clientId;
             const deploymentId = valid['https://purl.imsglobal.org/spec/lti/claim/deployment_id'];
-            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId);
+            const contextProperties = {
+              path: req.path,
+              user: valid.sub,
+              roles: valid['https://purl.imsglobal.org/spec/lti/claim/roles'],
+              targetLinkUri: valid['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
+              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
+              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
+              custom: valid['https://purl.imsglobal.org/spec/lti/claim/custom'],
+              launchPresentation: valid['https://purl.imsglobal.org/spec/lti/claim/launch_presentation'],
+              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
+              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
+              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
+              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
+              endpoint: valid['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'],
+              namesRoles: valid['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']
+            };
+            const hashOfContextProperties = crypto.createHash('sha256').update(JSON.stringify(contextProperties)).digest('hex');
+
+            // Appending hashOfContextProperties is a temporary fix to prevent overwriting existing database entries. See: https://github.com/Cvmcosta/ltijs/issues/181 
+            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + "_" + hashOfContextProperties);
             const platformCode = encodeURIComponent('lti' + Buffer.from(valid.iss + clientId + deploymentId).toString('base64'));
 
             // Mount platform token
@@ -381,20 +400,7 @@ class Provider {
             // Mount context token
             const contextToken = {
               contextId,
-              path: req.path,
-              user: valid.sub,
-              roles: valid['https://purl.imsglobal.org/spec/lti/claim/roles'],
-              targetLinkUri: valid['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
-              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
-              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
-              custom: valid['https://purl.imsglobal.org/spec/lti/claim/custom'],
-              launchPresentation: valid['https://purl.imsglobal.org/spec/lti/claim/launch_presentation'],
-              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
-              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
-              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
-              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
-              endpoint: valid['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'],
-              namesRoles: valid['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']
+              ...contextProperties
             };
 
             // Store contextToken in database

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -256,27 +256,20 @@ class Provider {
             const clientId = valid.clientId
             const deploymentId = valid['https://purl.imsglobal.org/spec/lti/claim/deployment_id']
                         
-            const contextProperties = {
+            const additionalContextProperties = {
               path: req.path,
-              user: valid.sub,
               roles: valid['https://purl.imsglobal.org/spec/lti/claim/roles'],
               targetLinkUri: valid['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
-              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
-              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
               custom: valid['https://purl.imsglobal.org/spec/lti/claim/custom'],
               launchPresentation: valid['https://purl.imsglobal.org/spec/lti/claim/launch_presentation'],
-              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
-              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
-              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
-              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
               endpoint: valid['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'],
-              namesRoles: valid['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']
+              namesRoles: valid['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice'],
             }
 
-            const hashOfContextProperties = crypto.createHash('sha256').update(JSON.stringify(contextProperties)).digest('hex')
+            const hashOfAdditionalContextProperties = crypto.createHash('sha256').update(JSON.stringify(additionalContextProperties)).digest('hex')
             
             // Appending hashOfContextProperties is a temporary fix to prevent overwriting existing database entries in some scenarios. See: https://github.com/Cvmcosta/ltijs/issues/181 
-            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + "_" + hashOfContextProperties)
+            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + "_" + hashOfAdditionalContextProperties)
 
             const platformCode = encodeURIComponent('lti' + Buffer.from(valid.iss + clientId + deploymentId).toString('base64'))
 
@@ -302,7 +295,14 @@ class Provider {
             // Mount context token
             const contextToken = {
               contextId,
-              ...contextProperties
+              user: valid.sub,
+              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
+              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
+              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
+              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
+              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
+              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
+              ...additionalContextProperties
             }
 
             // Store contextToken in database

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -255,8 +255,29 @@ class Provider {
 
             const clientId = valid.clientId
             const deploymentId = valid['https://purl.imsglobal.org/spec/lti/claim/deployment_id']
+                        
+            const contextProperties = {
+              path: req.path,
+              user: valid.sub,
+              roles: valid['https://purl.imsglobal.org/spec/lti/claim/roles'],
+              targetLinkUri: valid['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
+              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
+              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
+              custom: valid['https://purl.imsglobal.org/spec/lti/claim/custom'],
+              launchPresentation: valid['https://purl.imsglobal.org/spec/lti/claim/launch_presentation'],
+              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
+              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
+              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
+              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
+              endpoint: valid['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'],
+              namesRoles: valid['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']
+            }
 
-            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId)
+            const hashOfContextProperties = crypto.createHash('sha256').update(JSON.stringify(contextProperties)).digest('hex')
+            
+            // Appending hashOfContextProperties is a temporary fix to prevent overwriting existing database entries in some scenarios. See: https://github.com/Cvmcosta/ltijs/issues/181 
+            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + "_" + hashOfContextProperties)
+
             const platformCode = encodeURIComponent('lti' + Buffer.from(valid.iss + clientId + deploymentId).toString('base64'))
 
             // Mount platform token
@@ -281,20 +302,7 @@ class Provider {
             // Mount context token
             const contextToken = {
               contextId,
-              path: req.path,
-              user: valid.sub,
-              roles: valid['https://purl.imsglobal.org/spec/lti/claim/roles'],
-              targetLinkUri: valid['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
-              context: valid['https://purl.imsglobal.org/spec/lti/claim/context'],
-              resource: valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'],
-              custom: valid['https://purl.imsglobal.org/spec/lti/claim/custom'],
-              launchPresentation: valid['https://purl.imsglobal.org/spec/lti/claim/launch_presentation'],
-              messageType: valid['https://purl.imsglobal.org/spec/lti/claim/message_type'],
-              version: valid['https://purl.imsglobal.org/spec/lti/claim/version'],
-              deepLinkingSettings: valid['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'],
-              lis: valid['https://purl.imsglobal.org/spec/lti/claim/lis'],
-              endpoint: valid['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint'],
-              namesRoles: valid['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']
+              ...contextProperties
             }
 
             // Store contextToken in database


### PR DESCRIPTION
Closes #181 

See changed files. 

Changes should be backwards compatible, as far as I understand it: 
- Database schema was not changed
- Old database entries and ltiks should still work. New LTI launches will create new database entries and ltiks with the new format for the contextId.