### PR TITLE
Nonce security when the tokenMaxAge is set to false #175

### DIFF
--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -637,19 +637,20 @@ class Provider {
           // Setting up validation info
           const cookieOptions = JSON.parse(JSON.stringify((0, _classPrivateFieldGet2.default)(this, _cookieOptions)));
           cookieOptions.maxAge = 60 * 1000; // Adding max age to state cookie = 1min
-          res.cookie('state' + state, iss, cookieOptions); // Create nonce parameter used to prevent replay attack
+          res.cookie('state' + state, iss, cookieOptions);
 
-          const nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``); // Check if nonce is unique
-
+          // Create nonce parameter used to prevent replay attack
+          const nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``);
+          // Check if nonce is unique
           while (await this.Database.Get(false, 'nonce', {
             nonce: nonce
-          })) nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``); //Store nonce
-
-
+          })) nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``);
+          //Store nonce
           await this.Database.Insert(false, 'nonce', {
             nonce
-          }); // Redirect to authentication endpoint
+          });
 
+          // Redirect to authentication endpoint
           const query = await Request.ltiAdvantageLogin(params, platform, state, nonce);
           provMainDebug('Login request: ');
           provMainDebug(query);

--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -637,10 +637,20 @@ class Provider {
           // Setting up validation info
           const cookieOptions = JSON.parse(JSON.stringify((0, _classPrivateFieldGet2.default)(this, _cookieOptions)));
           cookieOptions.maxAge = 60 * 1000; // Adding max age to state cookie = 1min
-          res.cookie('state' + state, iss, cookieOptions);
+          res.cookie('state' + state, iss, cookieOptions); // Create nonce parameter used to prevent replay attack
 
-          // Redirect to authentication endpoint
-          const query = await Request.ltiAdvantageLogin(params, platform, state);
+          const nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``); // Check if nonce is unique
+
+          while (await this.Database.Get(false, 'nonce', {
+            nonce: nonce
+          })) nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``); //Store nonce
+
+
+          await this.Database.Insert(false, 'nonce', {
+            nonce
+          }); // Redirect to authentication endpoint
+
+          const query = await Request.ltiAdvantageLogin(params, platform, state, nonce);
           provMainDebug('Login request: ');
           provMainDebug(query);
           res.redirect(url.format({

--- a/dist/Utils/Auth.js
+++ b/dist/Utils/Auth.js
@@ -245,12 +245,10 @@ class Auth {
     const savedNonce = await Database.Get(false, 'nonce', {
       nonce: token.nonce
     });
-
     if (!savedNonce) {
       provAuthDebug('Nonce have been Deleted Before, nonce not found in Database');
       throw new Error('NONCE_ALREADY_RECEIVED');
     }
-
     provAuthDebug('Deleting validated nonce');
     Database.Delete('nonce', {
       nonce: token.nonce

--- a/dist/Utils/Auth.js
+++ b/dist/Utils/Auth.js
@@ -242,11 +242,17 @@ class Auth {
   static async validateNonce(token, Database) {
     provAuthDebug('Validating nonce');
     provAuthDebug('Nonce: ' + token.nonce);
-    if (await Database.Get(false, 'nonce', {
+    const savedNonce = await Database.Get(false, 'nonce', {
       nonce: token.nonce
-    })) throw new Error('NONCE_ALREADY_RECEIVED');
-    provAuthDebug('Storing nonce');
-    await Database.Insert(false, 'nonce', {
+    });
+
+    if (!savedNonce) {
+      provAuthDebug('Nonce have been Deleted Before, nonce not found in Database');
+      throw new Error('NONCE_ALREADY_RECEIVED');
+    }
+
+    provAuthDebug('Deleting validated nonce');
+    Database.Delete('nonce', {
       nonce: token.nonce
     });
     return true;

--- a/dist/Utils/Database.js
+++ b/dist/Utils/Database.js
@@ -171,7 +171,7 @@ class Database {
       nonce: String,
       createdAt: {
         type: Date,
-        expires: 10,
+        expires: 3600,
         default: Date.now
       }
     });

--- a/dist/Utils/Request.js
+++ b/dist/Utils/Request.js
@@ -8,7 +8,7 @@ class Request {
      * @param {object} platform - Platform Object.
      * @param {String} state - State parameter, used to validate the response.
      */
-  static async ltiAdvantageLogin(request, platform, state) {
+  static async ltiAdvantageLogin(request, platform, state, nonce) {
     const query = {
       response_type: 'id_token',
       response_mode: 'form_post',
@@ -17,7 +17,7 @@ class Request {
       client_id: request.client_id || (await platform.platformClientId()),
       redirect_uri: request.target_link_uri,
       login_hint: request.login_hint,
-      nonce: encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``),
+      nonce: nonce,
       prompt: 'none',
       state
     };

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -521,8 +521,15 @@ class Provider {
           cookieOptions.maxAge = 60 * 1000 // Adding max age to state cookie = 1min
           res.cookie('state' + state, iss, cookieOptions)
 
+          // Create nonce parameter used to prevent replay attack
+          const nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+          // Check if nonce is unique
+          while (await this.Database.Get(false, 'nonce', { nonce: nonce })) nonce = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+          //Store nonce
+          await this.Database.Insert(false, 'nonce', { nonce })
+
           // Redirect to authentication endpoint
-          const query = await Request.ltiAdvantageLogin(params, platform, state)
+          const query = await Request.ltiAdvantageLogin(params, platform, state, nonce)
           provMainDebug('Login request: ')
           provMainDebug(query)
           res.redirect(url.format({

--- a/src/Utils/Auth.js
+++ b/src/Utils/Auth.js
@@ -222,6 +222,8 @@ class Auth {
      * @param {Object} token - Id token you wish to validate.
      */
   static async validateNonce (token, Database) {
+    provAuthDebug('Validating nonce');
+    provAuthDebug('Nonce: ' + token.nonce);
     const savedNonce = await Database.Get(false, 'nonce', { nonce: token.nonce })
     if (!savedNonce) {
       provAuthDebug('Nonce have been Deleted Before, nonce not found in Database')

--- a/src/Utils/Auth.js
+++ b/src/Utils/Auth.js
@@ -222,12 +222,14 @@ class Auth {
      * @param {Object} token - Id token you wish to validate.
      */
   static async validateNonce (token, Database) {
-    provAuthDebug('Validating nonce')
-    provAuthDebug('Nonce: ' + token.nonce)
+    const savedNonce = await Database.Get(false, 'nonce', { nonce: token.nonce })
+    if (!savedNonce) {
+      provAuthDebug('Nonce have been Deleted Before, nonce not found in Database')
+      throw new Error('NONCE_ALREADY_RECEIVED')
+    }
 
-    if (await Database.Get(false, 'nonce', { nonce: token.nonce })) throw new Error('NONCE_ALREADY_RECEIVED')
-    provAuthDebug('Storing nonce')
-    await Database.Insert(false, 'nonce', { nonce: token.nonce })
+    provAuthDebug('Deleting validated nonce')
+    Database.Delete('nonce', { nonce: token.nonce })
 
     return true
   }

--- a/src/Utils/Database.js
+++ b/src/Utils/Database.js
@@ -112,7 +112,7 @@ class Database {
 
     const nonceSchema = new Schema({
       nonce: String,
-      createdAt: { type: Date, expires: 10, default: Date.now }
+      createdAt: { type: Date, expires: 3600, default: Date.now }
     })
     nonceSchema.index({ nonce: 1 })
 

--- a/src/Utils/Request.js
+++ b/src/Utils/Request.js
@@ -6,7 +6,7 @@ class Request {
      * @param {object} platform - Platform Object.
      * @param {String} state - State parameter, used to validate the response.
      */
-  static async ltiAdvantageLogin (request, platform, state) {
+  static async ltiAdvantageLogin (request, platform, state, nonce) {
     const query = {
       response_type: 'id_token',
       response_mode: 'form_post',
@@ -15,7 +15,7 @@ class Request {
       client_id: request.client_id || await platform.platformClientId(),
       redirect_uri: request.target_link_uri,
       login_hint: request.login_hint,
-      nonce: encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``),
+      nonce: nonce,
       prompt: 'none',
       state
     }


### PR DESCRIPTION
Save Nonce in Database while sending the login request and delete on receiving the launch request, so that replay attacks won't be entertained as nonce cannot be reused in replay attacks after deletion