### PR TITLE
Option for custom context on serverless Express server

### DIFF
--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -41,6 +41,7 @@ var _ltiaas = /*#__PURE__*/new WeakMap();
 var _tokenMaxAge = /*#__PURE__*/new WeakMap();
 var _cookieOptions = /*#__PURE__*/new WeakMap();
 var _setup = /*#__PURE__*/new WeakMap();
+var _path = /*#__PURE__*/new WeakMap();
 var _connectCallback2 = /*#__PURE__*/new WeakMap();
 var _deepLinkingCallback2 = /*#__PURE__*/new WeakMap();
 var _dynamicRegistrationCallback2 = /*#__PURE__*/new WeakMap();
@@ -69,6 +70,8 @@ class Provider {
     });
     // Setup flag
     _classPrivateFieldInitSpec(this, _setup, false);
+    // if provided, the "base" path for the URLs managed by the LTIJS Express server
+    _classPrivateFieldInitSpec(this, _path, '');
     _classPrivateFieldInitSpec(this, _connectCallback2, async (token, req, res, next) => {
       return next();
     });
@@ -393,7 +396,7 @@ class Provider {
             query.append('ltik', newLtik);
             const urlSearchParams = query.toString();
             provMainDebug('Redirecting to endpoint with ltik');
-            return res.redirect(req.baseUrl + req.path + '?' + urlSearchParams);
+            return res.redirect(req.baseUrl + (_classPrivateFieldGet(_path, this) || "") + req.path + '?' + urlSearchParams);
           } else {
             const state = req.body.state;
             if (state) {
@@ -632,6 +635,7 @@ class Provider {
      * @param {Number} [options.port] - Deployment port. 3000 by default.
      * @param {Boolean} [options.silent] - If true, disables initial startup message.
      * @param {Boolean} [options.serverless] - If true, Ltijs does not start an Express server instance. This allows usage as a middleware and with services like AWS. Ignores 'port' parameter.
+     * @param {String} [options.path] - If the serverless Express is assigned to a sub-path in your WebServer, provide its path in the options.path. This will make it possible to redirect correctly to the tool provider
      * @returns {Promise<true>}
      */
   async deploy(options) {
@@ -648,8 +652,13 @@ class Provider {
       // Starts server on given port
 
       if (options && options.serverless) {
+        // if the serverless Express is assigned to a sub-path in your WebServer, provide its path in the options.path.
+        // This will make it possible to redirect correctly to the tool provider
+        if (options.path) _classPrivateFieldSet(_path, this, options.path);
         if (!conf.silent) {
           console.log('Ltijs started in serverless mode...');
+          const message = `LTI Provider will handle requests on the current server endpoints` + `\n >App Route: ${_classPrivateFieldGet(_path, this)}${_classPrivateFieldGet(_appRoute, this)}` + `\n >Initiate Login Route: ${_classPrivateFieldGet(_path, this)}${_classPrivateFieldGet(_loginRoute, this)}` + `\n >Keyset Route: ${_classPrivateFieldGet(_path, this)}${_classPrivateFieldGet(_keysetRoute, this)}` + `\n >Dynamic Registration Route: ${_classPrivateFieldGet(_path, this)}${_classPrivateFieldGet(_dynRegRoute, this)}`;
+          console.log('  _   _______ _____      _  _____\n' + ' | | |__   __|_   _|    | |/ ____|\n' + ' | |    | |    | |      | | (___  \n' + ' | |    | |    | |  _   | |\\___ \\ \n' + ' | |____| |   _| |_| |__| |____) |\n' + ' |______|_|  |_____|\\____/|_____/ \n\n', message);
         }
       } else {
         await _classPrivateFieldGet(_server, this).listen(conf.port);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ltijs",
-  "version": "5.9.4",
+  "version": "5.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ltijs",
-      "version": "5.9.4",
+      "version": "5.9.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.4",


### PR DESCRIPTION
When using the servless options, LTIJS defaults to the requester baseUrl and its "/" context when redirecting back to our application. This makes it impossible for this to work in situations where we want LTIjs to use a separate context from the one used by the main web application.

This PR makes it possible to specify a custom context that will be used by the Express server when dealing with LTIjs messaging.

Example usage:

```
  provider = Provider.setup(
    ltiSignKey,
    {
      url: ltiDB
    },
    {
      // options
      tokenMaxAge: 60 * 60, // 1 hour
      appRoute: "/launch",
      loginRoute: "/login",
      cookies,
      dynRegRoute: "/register",
      dynReg: {
        url: `${settings?.public?.baseUrl}/ltitool`,
        name: `${settings?.private?.lti?.toolName || "LTI Tool"}`,
        description: `${settings?.private?.lti?.toolDesc || "LTI Tool Description"}`,
        redirectUris: [],
        autoActivate: true
      }
    },
    log
  );

  // deploy the LTI provider in serverless mode and bind it to the context '/ltitool'
  await Provider.deploy({ serverless: true, path: "/ltitool" });
```

This will result in "/ltitool/launch", "/ltitool/login", "/ltitool/register" to be used by the Express server as intended.
  