### PR TITLE
Switch from cookie to localStorage login flow

### DIFF
--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -23,9 +23,19 @@ const DynamicRegistration = require('./Services/DynamicRegistration');
 const url = require('fast-url-parser');
 const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
+const {
+  sign,
+  unsign
+} = require('cookie-signature');
+const path = require('path');
+const {
+  sprightly
+} = require('sprightly');
 const provAuthDebug = require('debug')('provider:auth');
 const provMainDebug = require('debug')('provider:main');
 const provDynamicRegistrationDebug = require('debug')('provider:dynamicRegistrationService');
+const loginRedirect = path.join(__dirname, '../Templates', 'LoginRedirect.html');
+const signedStateForm = path.join(__dirname, '../Templates', 'SignedStateForm.html');
 
 /**
  * @descripttion LTI Provider Class that implements the LTI 1.3 protocol and services.
@@ -149,7 +159,7 @@ class Provider {
   }
   /**
      * @description Provider configuration method.
-     * @param {String} encryptionkey - Secret used to sign cookies and encrypt other info.
+     * @param {String} encryptionkey - Secret used to sign session cookies and encrypt other info.
      * @param {Object} database - Database configuration.
      * @param {String} database.url - Database Url (Ex: mongodb://localhost/applicationdb).
      * @param {Object} [database.plugin] - If set, must be the Database object of the desired database plugin.
@@ -173,7 +183,7 @@ class Provider {
      * @param {Boolean} [options.cookies.secure = false] - Cookie secure parameter. If true, only allows cookies to be passed over https.
      * @param {String} [options.cookies.sameSite = 'Lax'] - Cookie sameSite parameter. If cookies are going to be set across domains, set this parameter to 'None'.
      * @param {String} [options.cookies.domain] - Cookie domain parameter. This parameter can be used to specify a domain so that the cookies set by Ltijs can be shared between subdomains.
-     * @param {Boolean} [options.devMode = false] - If true, does not require state and session cookies to be present (If present, they are still validated). This allows ltijs to work on development environments where cookies cannot be set. THIS SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT.
+     * @param {Boolean} [options.devMode = false] - If true, does not require session cookies to be present (If present, they are still validated). This allows ltijs to work on development environments where cookies cannot be set. THIS SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT.
      * @param {Number} [options.tokenMaxAge = 10] - Sets the idToken max age allowed in seconds. Defaults to 10 seconds. If false, disables max age validation.
      * @param {Object} [options.dynReg] - Setup for the Dynamic Registration Service.
      * @param {String} [options.dynReg.url] - Tool Provider main URL. (Ex: 'https://tool.example.com')
@@ -255,35 +265,36 @@ class Provider {
       try {
         // Retrieving ltik token
         const ltik = req.token;
-        // Retrieving cookies
-        const cookies = req.signedCookies;
-        provMainDebug('Cookies received: ');
-        provMainDebug(cookies);
         if (!ltik) {
-          const idtoken = req.body.id_token;
-          if (idtoken) {
+          if (req.body.id_token && req.body.state) {
             // No ltik found but request contains an idtoken
             provMainDebug('Received idtoken for validation');
-
-            // Retrieves state
+            const idtoken = req.body.id_token;
             const state = req.body.state;
-
-            // Retrieving validation parameters from cookies
+            const signedState = req.body.signed_state;
             provAuthDebug('Response state: ' + state);
-            const validationCookie = cookies['state' + state];
+            if (!signedState) {
+              // Missing signed state, so render template to retrieve it from local storage
+              return res.send(sprightly(signedStateForm, {
+                id_token: idtoken,
+                state,
+                key: `state_${state}`
+              }));
+            }
+            if (unsign(signedState, _classPrivateFieldGet(_ENCRYPTIONKEY2, this)) !== state) {
+              throw new Error('INVALID_STATE');
+            }
             const validationParameters = {
-              iss: validationCookie,
               maxAge: _classPrivateFieldGet(_tokenMaxAge, this)
             };
-            const valid = await Auth.validateToken(idtoken, _classPrivateFieldGet(_devMode, this), validationParameters, this.getPlatform, _classPrivateFieldGet(_ENCRYPTIONKEY2, this), this.Database);
+            const valid = await Auth.validateToken(idtoken, validationParameters, this.getPlatform, _classPrivateFieldGet(_ENCRYPTIONKEY2, this), this.Database);
 
             // Retrieve State object from Database
             const savedState = await this.Database.Get(false, 'state', {
               state
             });
 
-            // Deletes state validation cookie and Database entry
-            res.clearCookie('state' + state, _classPrivateFieldGet(_cookieOptions, this));
+            // Delete state Database entry
             if (savedState) this.Database.Delete('state', {
               state
             });
@@ -397,11 +408,10 @@ class Provider {
           } else {
             const state = req.body.state;
             if (state) {
-              provMainDebug('Deleting state cookie and Database entry');
+              provMainDebug('Deleting state Database entry');
               const savedState = await this.Database.Get(false, 'state', {
                 state
               });
-              res.clearCookie('state' + state, _classPrivateFieldGet(_cookieOptions, this));
               if (savedState) this.Database.Delete('state', {
                 state
               });
@@ -451,6 +461,9 @@ class Provider {
         let user = validLtik.user;
         if (!_classPrivateFieldGet(_ltiaas, this)) {
           provMainDebug('Attempting to retrieve matching session cookie');
+          const cookies = req.signedCookies;
+          provMainDebug('Cookies received: ');
+          provMainDebug(cookies);
           const cookieUser = cookies[platformCode];
           if (!cookieUser) {
             if (!_classPrivateFieldGet(_devMode, this)) user = false;else {
@@ -502,11 +515,10 @@ class Provider {
       } catch (err) {
         const state = req.body.state;
         if (state) {
-          provMainDebug('Deleting state cookie and Database entry');
+          provMainDebug('Deleting state Database entry');
           const savedState = await this.Database.Get(false, 'state', {
             state
           });
-          res.clearCookie('state' + state, _classPrivateFieldGet(_cookieOptions, this));
           if (savedState) this.Database.Delete('state', {
             state
           });
@@ -575,18 +587,18 @@ class Provider {
             });
           }
 
-          // Setting up validation info
-          const cookieOptions = JSON.parse(JSON.stringify(_classPrivateFieldGet(_cookieOptions, this)));
-          cookieOptions.maxAge = 60 * 1000; // Adding max age to state cookie = 1min
-          res.cookie('state' + state, iss, cookieOptions);
-
           // Redirect to authentication endpoint
           const query = await Request.ltiAdvantageLogin(params, platform, state);
           provMainDebug('Login request: ');
           provMainDebug(query);
-          res.redirect(url.format({
+          const targetUrl = url.format({
             pathname: await platform.platformAuthEndpoint(),
             query
+          });
+          return res.send(sprightly(loginRedirect, {
+            targetUrl,
+            key: `state_${state}`,
+            value: sign(state, _classPrivateFieldGet(_ENCRYPTIONKEY2, this))
           }));
         } else {
           provMainDebug('Unregistered platform attempting connection: ' + iss + ', clientId: ' + clientId);
@@ -661,7 +673,7 @@ class Provider {
           console.log('  _   _______ _____      _  _____\n' + ' | | |__   __|_   _|    | |/ ____|\n' + ' | |    | |    | |      | | (___  \n' + ' | |    | |    | |  _   | |\\___ \\ \n' + ' | |____| |   _| |_| |__| |____) |\n' + ' |______|_|  |_____|\\____/|_____/ \n\n', message);
         }
       }
-      if (_classPrivateFieldGet(_devMode, this) && !conf.silent) console.log('\nStarting in Dev Mode, state validation and session cookies will not be required. THIS SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT!');
+      if (_classPrivateFieldGet(_devMode, this) && !conf.silent) console.log('\nStarting in Dev Mode, session cookies will not be required. THIS SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT!');
 
       // Sets up gracefull shutdown
       process.on('SIGINT', async () => {
@@ -697,19 +709,7 @@ class Provider {
      * @example .onConnect((token, request, response)=>{response.send('OK')})
      * @returns {true}
      */
-  onConnect(_connectCallback, options) {
-    /* istanbul ignore next */
-    if (options) {
-      if (options.sameSite || options.secure) console.log('Deprecation Warning: The optional parameters of the onConnect() method are now deprecated and will be removed in the 6.0 release. Cookie parameters can be found in the main Ltijs constructor options: ... { cookies: { secure: true, sameSite: \'None\' }.');
-      if (options.sessionTimeout || options.invalidToken) console.log('Deprecation Warning: The optional parameters of the onConnect() method are now deprecated and will be removed in the 6.0 release. Invalid token and Session Timeout methods can now be set with the onSessionTimeout() and onInvalidToken() methods.');
-      if (options.sameSite) {
-        _classPrivateFieldGet(_cookieOptions, this).sameSite = options.sameSite;
-        if (options.sameSite.toLowerCase() === 'none') _classPrivateFieldGet(_cookieOptions, this).secure = true;
-      }
-      if (options.secure === true) _classPrivateFieldGet(_cookieOptions, this).secure = true;
-      if (options.sessionTimeout) _classPrivateFieldSet(_sessionTimeoutCallback2, this, options.sessionTimeout);
-      if (options.invalidToken) _classPrivateFieldSet(_invalidTokenCallback2, this, options.invalidToken);
-    }
+  onConnect(_connectCallback) {
     if (_connectCallback) {
       _classPrivateFieldSet(_connectCallback2, this, _connectCallback);
       return true;

--- a/dist/Templates/LoginRedirect.html
+++ b/dist/Templates/LoginRedirect.html
@@ -1,0 +1,4 @@
+<script>
+  localStorage.setItem('{{key}}', '{{value}}');
+  window.location.href = '{{targetUrl}}';
+</script>

--- a/dist/Templates/SignedStateForm.html
+++ b/dist/Templates/SignedStateForm.html
@@ -1,0 +1,17 @@
+<form id="ltijs_launch" style="display: none;" action="" method="post">
+	<input type="hidden" name="id_token" value="{{id_token}}" /> 
+	<input type="hidden" name="state" value="{{state}}" />
+	<input type="hidden" name="signed_state" id="signed_state" value="" />
+</form>
+<script>
+(function() {
+	const signedState = localStorage.getItem('{{key}}');
+	if (!signedState) {
+		alert('Missing signed state! Please try again.');
+		return;
+	}
+	document.getElementById('signed_state').value = signedState;
+	localStorage.removeItem('{{key}}');
+	document.getElementById('ltijs_launch').submit();
+})();
+</script>

--- a/dist/Utils/Auth.js
+++ b/dist/Utils/Auth.js
@@ -69,27 +69,18 @@ class Auth {
   /**
      * @description Resolves a promisse if the token is valid following LTI 1.3 standards.
      * @param {String} token - JWT token to be verified.
-     * @param {Boolean} devMode - DevMode option.
      * @param {Object} validationParameters - Stored validation parameters retrieved from database.
      * @param {Function} getPlatform - getPlatform function to get the platform that originated the token.
      * @param {String} ENCRYPTIONKEY - Encription key.
      * @returns {Promise}
      */
-  static async validateToken(token, devMode, validationParameters, getPlatform, ENCRYPTIONKEY, Database) {
+  static async validateToken(token, validationParameters, getPlatform, ENCRYPTIONKEY, Database) {
     const decoded = jwt.decode(token, {
       complete: true
     });
     if (!decoded) throw new Error('INVALID_JWT_RECEIVED');
     const kid = decoded.header.kid;
     validationParameters.alg = decoded.header.alg;
-    provAuthDebug('Attempting to validate iss claim');
-    provAuthDebug('Request Iss claim: ' + validationParameters.iss);
-    provAuthDebug('Response Iss claim: ' + decoded.payload.iss);
-    if (!validationParameters.iss) {
-      if (!devMode) throw new Error('MISSING_VALIDATION_COOKIE');else {
-        provAuthDebug('Dev Mode enabled: Missing state validation cookies will be ignored');
-      }
-    } else if (validationParameters.iss !== decoded.payload.iss) throw new Error('ISS_CLAIM_DOES_NOT_MATCH');
     provAuthDebug('Attempting to retrieve registered platform');
     let platform;
     if (!Array.isArray(decoded.payload.aud)) platform = await getPlatform(decoded.payload.iss, decoded.payload.aud, ENCRYPTIONKEY, Database);else {

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -639,22 +639,7 @@ class Provider {
      * @example .onConnect((token, request, response)=>{response.send('OK')})
      * @returns {true}
      */
-  onConnect (_connectCallback, options) {
-    /* istanbul ignore next */
-    if (options) {
-      if (options.sameSite || options.secure) console.log('Deprecation Warning: The optional parameters of the onConnect() method are now deprecated and will be removed in the 6.0 release. Cookie parameters can be found in the main Ltijs constructor options: ... { cookies: { secure: true, sameSite: \'None\' }.')
-
-      if (options.sessionTimeout || options.invalidToken) console.log('Deprecation Warning: The optional parameters of the onConnect() method are now deprecated and will be removed in the 6.0 release. Invalid token and Session Timeout methods can now be set with the onSessionTimeout() and onInvalidToken() methods.')
-
-      if (options.sameSite) {
-        this.#cookieOptions.sameSite = options.sameSite
-        if (options.sameSite.toLowerCase() === 'none') this.#cookieOptions.secure = true
-      }
-      if (options.secure === true) this.#cookieOptions.secure = true
-      if (options.sessionTimeout) this.#sessionTimeoutCallback = options.sessionTimeout
-      if (options.invalidToken) this.#invalidTokenCallback = options.invalidToken
-    }
-
+  onConnect (_connectCallback) {
     if (_connectCallback) {
       this.#connectCallback = _connectCallback
       return true

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -248,12 +248,10 @@ class Provider {
             }
 
             const validationParameters = {
-              // TODO: iss was previously stored in state cookie but we're not doing the same with localStorage
-              iss: '',
               maxAge: this.#tokenMaxAge
             }
 
-            const valid = await Auth.validateToken(idtoken, this.#devMode, validationParameters, this.getPlatform, this.#ENCRYPTIONKEY, this.Database)
+            const valid = await Auth.validateToken(idtoken, validationParameters, this.getPlatform, this.#ENCRYPTIONKEY, this.Database)
 
             // Retrieve State object from Database
             const savedState = await this.Database.Get(false, 'state', { state })

--- a/src/Templates/LoginRedirect.html
+++ b/src/Templates/LoginRedirect.html
@@ -1,0 +1,4 @@
+<script>
+  localStorage.setItem('{{key}}', '{{value}}');
+  window.location.href = '{{targetUrl}}';
+</script>

--- a/src/Templates/SignedStateForm.html
+++ b/src/Templates/SignedStateForm.html
@@ -1,0 +1,17 @@
+<form id="ltijs_launch" style="display: none;" action="" method="post">
+	<input type="hidden" name="id_token" value="{{id_token}}" /> 
+	<input type="hidden" name="state" value="{{state}}" />
+	<input type="hidden" name="signed_state" id="signed_state" value="" />
+</form>
+<script>
+(function() {
+	const signedState = localStorage.getItem('{{key}}');
+	if (!signedState) {
+		alert('Missing signed state! Please try again.');
+		return;
+	}
+	document.getElementById('signed_state').value = signedState;
+	localStorage.removeItem('{{key}}');
+	document.getElementById('ltijs_launch').submit();
+})();
+</script>

--- a/src/Utils/Auth.js
+++ b/src/Utils/Auth.js
@@ -54,26 +54,17 @@ class Auth {
   /**
      * @description Resolves a promisse if the token is valid following LTI 1.3 standards.
      * @param {String} token - JWT token to be verified.
-     * @param {Boolean} devMode - DevMode option.
      * @param {Object} validationParameters - Stored validation parameters retrieved from database.
      * @param {Function} getPlatform - getPlatform function to get the platform that originated the token.
      * @param {String} ENCRYPTIONKEY - Encription key.
      * @returns {Promise}
      */
-  static async validateToken (token, devMode, validationParameters, getPlatform, ENCRYPTIONKEY, Database) {
+  static async validateToken (token, validationParameters, getPlatform, ENCRYPTIONKEY, Database) {
     const decoded = jwt.decode(token, { complete: true })
     if (!decoded) throw new Error('INVALID_JWT_RECEIVED')
 
     const kid = decoded.header.kid
     validationParameters.alg = decoded.header.alg
-
-    provAuthDebug('Attempting to validate iss claim')
-    provAuthDebug('Request Iss claim: ' + validationParameters.iss)
-    provAuthDebug('Response Iss claim: ' + decoded.payload.iss)
-    if (!validationParameters.iss) {
-      if (!devMode) throw new Error('MISSING_VALIDATION_COOKIE')
-      else { provAuthDebug('Dev Mode enabled: Missing state validation cookies will be ignored') }
-    } else if (validationParameters.iss !== decoded.payload.iss) throw new Error('ISS_CLAIM_DOES_NOT_MATCH')
 
     provAuthDebug('Attempting to retrieve registered platform')
     let platform

--- a/test/1-lti.js
+++ b/test/1-lti.js
@@ -207,6 +207,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('UNREGISTERED_PLATFORM')
     })
   })
   it('BadPayload - Wrong multiple aud claim. Expected to redirect to invalid token route', async () => {
@@ -224,6 +225,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('UNREGISTERED_PLATFORM')
     })
   })
   it('BadPayload - Multiple aud claim, wrong azp claim. Expected to redirect to invalid token route', async () => {
@@ -242,6 +244,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('AZP_DOES_NOT_MATCH_CLIENTID')
     })
   })
   // IMS Certification tests
@@ -252,6 +255,7 @@ describe('Testing LTI 1.3 flow', function () {
 
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('KID_NOT_FOUND')
     })
   })
   it('BadPayload - Incorrect KID in JWT header. Expected to redirect to invalid token route', async () => {
@@ -266,6 +270,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('KEY_NOT_FOUND')
     })
   })
   it('BadPayload - Wrong LTI Version. Expected to redirect to invalid token route', async () => {
@@ -283,6 +288,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('WRONG_LTI_VERSION_CLAIM')
     })
   })
   it('BadPayload - No LTI Version. Expected to redirect to invalid token route', async () => {
@@ -300,6 +306,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('NO_LTI_VERSION_CLAIM')
     })
   })
   it('BadPayload - Invalid LTI message. Expected to redirect to invalid token route', async () => {
@@ -310,6 +317,7 @@ describe('Testing LTI 1.3 flow', function () {
     const url = await lti.appRoute()
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('INVALID_JWT_RECEIVED')
     })
   })
   it('BadPayload - Missing LTI Claims. Expected to redirect to invalid token route', async () => {
@@ -327,6 +335,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('NO_MESSAGE_TYPE_CLAIM')
     })
   })
   it('BadPayload - Timestamps Incorrect. Expected to redirect to invalid token route', async () => {
@@ -345,6 +354,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('jwt expired')
     })
   })
   it('BadPayload - Messsage Type Claim Missing. Expected to redirect to invalid token route', async () => {
@@ -362,6 +372,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('NO_MESSAGE_TYPE_CLAIM')
     })
   })
   it('BadPayload - Role Claim Missing. Expected to redirect to invalid token route', async () => {
@@ -379,6 +390,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('NO_ROLES_CLAIM')
     })
   })
   it('BadPayload - Deployment Id Claim Missing. Expected to redirect to invalid token route', async () => {
@@ -396,6 +408,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('NO_DEPLOYMENT_ID_CLAIM')
     })
   })
   it('BadPayload - Resource Link Id Claim Missing. Expected to redirect to invalid token route', async () => {
@@ -413,6 +426,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('NO_RESOURCE_LINK_ID_CLAIM')
     })
   })
   it('BadPayload - User Claim Missing. Expected to redirect to invalid token route', async () => {
@@ -430,6 +444,7 @@ describe('Testing LTI 1.3 flow', function () {
     })
     return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;']).then(res => {
       expect(res.statusCode).to.equal(401)
+      expect(res.body.details.message).to.equal('NO_SUB_CLAIM')
     })
   })
   it('ValidPayload. Expected to return status 200', async () => {

--- a/test/2-grade.js
+++ b/test/2-grade.js
@@ -3,6 +3,7 @@
 
 const jwt = require('jsonwebtoken')
 const nock = require('nock')
+const { sign } = require('cookie-signature')
 
 const chai = require('chai')
 const chaiHttp = require('chai-http')
@@ -139,6 +140,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -165,7 +167,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const lineItems = JSON.parse(res.text)
       expect(lineItems.lineItems).to.exist // eslint-disable-line
@@ -177,6 +179,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -203,7 +206,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const lineItems = JSON.parse(res.text)
       expect(lineItems).to.deep.equal(lineItemsResponse[1])
@@ -215,6 +218,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -241,7 +245,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const lineItems = JSON.parse(res.text)
       expect(lineItems).to.deep.equal(lineItemsResponse[1])
@@ -253,6 +257,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -279,7 +284,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(204)
     })
   })
@@ -289,6 +294,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -320,7 +326,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const lineItem = JSON.parse(res.text)
       expect(lineItem).to.deep.equal(newLineItem)
@@ -332,6 +338,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -360,7 +367,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const deleteLineItems = JSON.parse(res.text)
       const response = {
@@ -383,6 +390,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -416,7 +424,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const scoreLineItems = JSON.parse(res.text)
       const response = {
@@ -439,6 +447,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -471,7 +480,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const scoreLineItems = JSON.parse(res.text)
       const response = {
@@ -491,6 +500,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -523,7 +533,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const response = JSON.parse(res.text)
       expect(response.scoreGiven).to.equal(90)
@@ -535,6 +545,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -577,7 +588,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const results = JSON.parse(res.text)
       expect(results).to.deep.equal(resultsResponse)
@@ -589,6 +600,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -641,7 +653,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     ]
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const results = JSON.parse(res.text)
       expect(results).to.deep.equal(resultsResponse)
@@ -653,6 +665,7 @@ describe('Testing Assignment and Grades Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -690,7 +703,7 @@ describe('Testing Assignment and Grades Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
       const response = JSON.parse(res.text)
       expect(response.scores).to.exist // eslint-disable-line

--- a/test/3-deeplinking.js
+++ b/test/3-deeplinking.js
@@ -3,6 +3,7 @@
 
 const jwt = require('jsonwebtoken')
 const nock = require('nock')
+const { sign } = require('cookie-signature')
 
 const cheerio = require('cheerio');
 
@@ -129,6 +130,7 @@ describe('Testing Deep Linking Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -141,7 +143,7 @@ describe('Testing Deep Linking Service', function () {
       return res.sendStatus(200)
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
     })
   })
@@ -151,6 +153,7 @@ describe('Testing Deep Linking Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     const plat = await lti.getPlatform(token.iss, token.aud)
@@ -178,7 +181,7 @@ describe('Testing Deep Linking Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(async res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(async res => {
       expect(res).to.have.status(200)
       const payload = jwt.verify(res.text, await plat.platformPublicKey())
       expect(payload['https://purl.imsglobal.org/spec/lti-dl/claim/content_items']).to.deep.include(item)
@@ -192,6 +195,7 @@ describe('Testing Deep Linking Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     const plat = await lti.getPlatform(token.iss, token.aud)
@@ -219,7 +223,7 @@ describe('Testing Deep Linking Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(async res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(async res => {
       expect(res).to.have.status(200)
 
       const $ = cheerio.load(res.text)

--- a/test/4-namesandroles.js
+++ b/test/4-namesandroles.js
@@ -3,6 +3,7 @@
 
 const jwt = require('jsonwebtoken')
 const nock = require('nock')
+const { sign } = require('cookie-signature')
 
 const chai = require('chai')
 const chaiHttp = require('chai-http')
@@ -107,6 +108,7 @@ describe('Testing Names and Roles Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -132,7 +134,7 @@ describe('Testing Names and Roles Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
 
       const members = JSON.parse(res.text)
@@ -145,6 +147,7 @@ describe('Testing Names and Roles Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -173,7 +176,7 @@ describe('Testing Names and Roles Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
 
       const result = JSON.parse(res.text)
@@ -189,6 +192,7 @@ describe('Testing Names and Roles Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -217,7 +221,7 @@ describe('Testing Names and Roles Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
 
       const result = JSON.parse(res.text)
@@ -233,6 +237,7 @@ describe('Testing Names and Roles Service', function () {
 
     const payload = signToken(token, '123456')
     const state = encodeURIComponent([...Array(25)].map(_ => (Math.random() * 36 | 0).toString(36)).join``)
+    const signedState = sign(state, 'LTIKEY')
     const url = await lti.appRoute()
 
     nock('http://localhost/moodle').get('/keyset').reply(200, {
@@ -258,7 +263,7 @@ describe('Testing Names and Roles Service', function () {
       }
     })
 
-    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state }).set('Cookie', ['state' + state + '=s%3Ahttp%3A%2F%2Flocalhost%2Fmoodle.fsJogjTuxtbJwvJcuG4esveQAlih67sfEltuwRM6MX0; Path=/; HttpOnly;', 'ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
+    return chai.request(lti.app).post(url).type('json').send({ id_token: payload, state, signed_state: signedState }).set('Cookie', ['ltiaHR0cDovL2xvY2FsaG9zdC9tb29kbGVDbGllbnRJZDEy=s%3A2.ZezwPKtv3Uibp4A%2F6cN0UzbIQlhA%2BTAKvbtN%2FvgGaCI; Path=/; HttpOnly; SameSite=None']).then(res => {
       expect(res).to.have.status(200)
 
       const members = JSON.parse(res.text)


### PR DESCRIPTION
Note: [PR 225](https://github.com/Cvmcosta/ltijs/pull/225) should be merged before this PR, as this PR includes commits from PR 255.

## Problem

To ensure successful LTI Launches in the future, LTIJS must eliminate its reliance on third-party cookies, which are currently used when an LTI Launch occurs within an iframe. Safari has already disabled third-party cookies by default and Chrome has begun its [phaseout process](https://developers.google.com/privacy-sandbox/3pcd).

## Solution

This PR introduces a new login method that utilizes local storage to maintain the user's state during the LTI handshake.

## Alternative Solutions

Alternative solutions considered:

1. **New LTI Protocol**: There's a new LTI protocol that enables tools to store state information within the LMS. The LMS stores data on behalf of the tool and the the tool accesses it via postMessage communication with the LMS (see [video](https://www.youtube.com/watch?v=60QY7HxPenk)). Although viable, this option is constrained by the fact that not all LMSs support the new protocol.
2. **sessionStorage**: Though technically better suited for our use case than localStorage due to its tab-based context, sessionStorage proved problematic in certain scenarios during extensive testing at LTIAAS (@Cvmcosta, please add details here).

## Completed Tasks

- [x] **Breaking change**: Remove deprecated `options` parameter from `onConnect` [8da09f81...](https://github.com/examind-ai/ltijs/commit/8da09f8176bad0ed50e085e7166fbc7f661f5670)
- [x] Add error message assertions to `BadPayload` unit tests to ensure backwards compatibility when migrating to localStorage login [adc6e9bb...](https://github.com/examind-ai/ltijs/commit/adc6e9bb53083c41aa49178871f8b0bf23e38dfa)
- [x] Switch from cookie to localStorage login flow
- [x] Remove issuer match validation, as the spec doesn't require it [4767e287...](https://github.com/examind-ai/ltijs/commit/4767e287093f8336833efc0bb9c8ddbe3429b19e)
- [x] Adapt unit tests to localStorage login [5b347bbb...](https://github.com/examind-ai/ltijs/commit/5b347bbb9c3f735ca8c8748648abbabfe2fc5a06)
- [x] Add unit test for invalid signed state [2c6168d4...](https://github.com/examind-ai/ltijs/commit/2c6168d41b1500f6a1210c4886c5f234fd32c32a)

## Tested Environments

### macOS

| Browser | Moodle | Canvas |
| ------- | ------ | ------ |
| Chrome  | ☑️     | ☑️     |
| Firefox | ☑️     | ☑️     |
| Safari  | ☑️     | ☑️     |

### Windows

| Browser | Moodle | Canvas |
| ------- | ------ | ------ |
| Chrome  | ☑️     | ☑️     |
| Edge    | ☑️     | ☑️     |
| Firefox | ☑️     | ☑️     |