### PR TITLE
enable chips partitioned cookies

### DIFF
--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -48,7 +48,8 @@ class Provider {
   #cookieOptions = {
     secure: false,
     httpOnly: true,
-    signed: true
+    signed: true,
+    partitioned: true
   }
 
   // Setup flag


### PR DESCRIPTION
This should help with browsers that have strict tracking prevention.

As mentioned in https://github.com/Cvmcosta/ltijs/issues/213