### PR TITLE
Clarify Resource Link ID terminology

### DIFF
--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -289,7 +289,7 @@ class Provider {
             });
             provAuthDebug('Successfully validated token!');
             const courseId = valid['https://purl.imsglobal.org/spec/lti/claim/context'] ? valid['https://purl.imsglobal.org/spec/lti/claim/context'].id : 'NF';
-            const resourceId = valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'] ? valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'].id : 'NF';
+            const resourceLinkId = valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'] ? valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'].id : 'NF';
             const clientId = valid.clientId;
             const deploymentId = valid['https://purl.imsglobal.org/spec/lti/claim/deployment_id'];
             const additionalContextProperties = {
@@ -304,7 +304,7 @@ class Provider {
             const hashOfAdditionalContextProperties = crypto.createHash('sha256').update(JSON.stringify(additionalContextProperties)).digest('hex');
 
             // Appending hashOfContextProperties is a temporary fix to prevent overwriting existing database entries in some scenarios. See: https://github.com/Cvmcosta/ltijs/issues/181
-            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + '_' + hashOfAdditionalContextProperties);
+            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceLinkId + '_' + hashOfAdditionalContextProperties);
             const platformCode = encodeURIComponent('lti' + Buffer.from(valid.iss + clientId + deploymentId).toString('base64'));
 
             // Mount platform token

--- a/docs/grading.md
+++ b/docs/grading.md
@@ -35,7 +35,11 @@ Ltijs implements the [LTI® 1.3 Assignment and Grading Service Specification](ht
 
 #### **This documentation is incomplete. The full Assignment and Grades documentation is being written and will come out soon...**
 
-> Note: `resourceLinkId` and `resourceId` refer to different AGS fields. Use `resourceLinkId: true` to work with the current LTI Resource Link (`resource_link.id`), or use `resourceId` to filter by a line item's `resourceId`.
+> Note: `resourceLinkId` and `resourceId` refer to different AGS fields.
+>
+> - In request options, use `resourceLinkId: true` to filter line items by the current LTI Resource Link (`resource_link.id`).
+> - In a line item object, `resourceLinkId` is the actual Resource Link ID value (for example, `idtoken.platformContext.resource.id`).
+> - Use `resourceId` to filter by a line item's `resourceId`.
 
 ___
 

--- a/docs/grading.md
+++ b/docs/grading.md
@@ -35,6 +35,8 @@ Ltijs implements the [LTI® 1.3 Assignment and Grading Service Specification](ht
 
 #### **This documentation is incomplete. The full Assignment and Grades documentation is being written and will come out soon...**
 
+> Note: `resourceLinkId` and `resourceId` refer to different AGS fields. Use `resourceLinkId: true` to work with the current LTI Resource Link (`resource_link.id`), or use `resourceId` to filter by a line item's `resourceId`.
+
 ___
 
 

--- a/docs/namesandroles.md
+++ b/docs/namesandroles.md
@@ -115,7 +115,7 @@ The `getMembers()` method allows us to apply filters to the request, and these f
 
  - **options.resourceLinkId**
 
- Accesses the Platform's Resource Link level membership service. This parameter will only take effect if the current context has a `resourceLinkId`.
+ Accesses the Platform's Resource Link level membership service by sending the current LTI Resource Link ID (`resource_link.id`) as the `rlid` parameter. This parameter will only take effect if the current context has a resource link.
 
    ```javascript
   const result = await lti.NamesAndRoles.getMembers(res.locals.token, { resourceLinkId: true, role: 'Learner', limit: 10, pages: 2 })

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -252,7 +252,7 @@ class Provider {
             provAuthDebug('Successfully validated token!')
 
             const courseId = valid['https://purl.imsglobal.org/spec/lti/claim/context'] ? valid['https://purl.imsglobal.org/spec/lti/claim/context'].id : 'NF'
-            const resourceId = valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'] ? valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'].id : 'NF'
+            const resourceLinkId = valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'] ? valid['https://purl.imsglobal.org/spec/lti/claim/resource_link'].id : 'NF'
 
             const clientId = valid.clientId
             const deploymentId = valid['https://purl.imsglobal.org/spec/lti/claim/deployment_id']
@@ -270,7 +270,7 @@ class Provider {
             const hashOfAdditionalContextProperties = crypto.createHash('sha256').update(JSON.stringify(additionalContextProperties)).digest('hex')
 
             // Appending hashOfContextProperties is a temporary fix to prevent overwriting existing database entries in some scenarios. See: https://github.com/Cvmcosta/ltijs/issues/181
-            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceId + '_' + hashOfAdditionalContextProperties)
+            const contextId = encodeURIComponent(valid.iss + clientId + deploymentId + courseId + '_' + resourceLinkId + '_' + hashOfAdditionalContextProperties)
 
             const platformCode = encodeURIComponent('lti' + Buffer.from(valid.iss + clientId + deploymentId).toString('base64'))
 


### PR DESCRIPTION
## What changed

- Clarified internal provider naming so code and generated `dist` use `resourceLinkId` when reading the LTI `resource_link.id` claim.
- Expanded grading docs to explain the difference between AGS `resourceLinkId` and `resourceId`, including the boolean filter vs string payload usage.
- Clarified Names and Roles docs to state that `resourceLinkId: true` sends the current Resource Link ID as the `rlid` parameter.

## Why

The existing terminology made it easy to confuse the LTI Resource Link identifier with AGS line item `resourceId`, which creates friction for users reading the docs and code.

## Impact

- No runtime behavior change intended.
- Documentation should make intent and API usage clearer.