### PR TITLE
Adds configurable RSA key size

### DIFF
--- a/dist/Provider/Provider.js
+++ b/dist/Provider/Provider.js
@@ -39,6 +39,7 @@ var _ENCRYPTIONKEY2 = /*#__PURE__*/new WeakMap();
 var _devMode = /*#__PURE__*/new WeakMap();
 var _ltiaas = /*#__PURE__*/new WeakMap();
 var _tokenMaxAge = /*#__PURE__*/new WeakMap();
+var _keySize2 = /*#__PURE__*/new WeakMap();
 var _cookieOptions = /*#__PURE__*/new WeakMap();
 var _setup = /*#__PURE__*/new WeakMap();
 var _connectCallback2 = /*#__PURE__*/new WeakMap();
@@ -62,6 +63,7 @@ class Provider {
     _classPrivateFieldInitSpec(this, _devMode, false);
     _classPrivateFieldInitSpec(this, _ltiaas, false);
     _classPrivateFieldInitSpec(this, _tokenMaxAge, 10);
+    _classPrivateFieldInitSpec(this, _keySize2, 4096);
     _classPrivateFieldInitSpec(this, _cookieOptions, {
       secure: false,
       httpOnly: true,
@@ -175,6 +177,7 @@ class Provider {
      * @param {String} [options.cookies.domain] - Cookie domain parameter. This parameter can be used to specify a domain so that the cookies set by Ltijs can be shared between subdomains.
      * @param {Boolean} [options.devMode = false] - If true, does not require state and session cookies to be present (If present, they are still validated). This allows ltijs to work on development environments where cookies cannot be set. THIS SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT.
      * @param {Number} [options.tokenMaxAge = 10] - Sets the idToken max age allowed in seconds. Defaults to 10 seconds. If false, disables max age validation.
+     * @param {Number} [options.keySize = 4096] - RSA modulus length in bits used by registerPlatform() when generating per-platform keypairs. Must be an integer >= 2048 (LTI 1.3 spec minimum). Lower values reduce the cost of the synchronous keygen call, which on small instances can take 5-30s at the 4096 default; 2048 is the LTI 1.3 spec minimum and matches the modulus length used by Canvas, Moodle, and Blackboard.
      * @param {Object} [options.dynReg] - Setup for the Dynamic Registration Service.
      * @param {String} [options.dynReg.url] - Tool Provider main URL. (Ex: 'https://tool.example.com')
      * @param {String} [options.dynReg.name] - Tool Provider name. (Ex: 'Tool Provider')
@@ -204,6 +207,10 @@ class Provider {
     if (options && options.devMode === true) _classPrivateFieldSet(_devMode, this, true);
     if (options && options.ltiaas === true) _classPrivateFieldSet(_ltiaas, this, true);
     if (options && options.tokenMaxAge !== undefined) _classPrivateFieldSet(_tokenMaxAge, this, options.tokenMaxAge);
+    if (options && options.keySize !== undefined) {
+      if (!Number.isInteger(options.keySize) || options.keySize < 2048) throw new Error('INVALID_KEYSIZE. Details: keySize must be an integer >= 2048 (LTI 1.3 spec minimum).');
+      _classPrivateFieldSet(_keySize2, this, options.keySize);
+    }
 
     // Cookie options
     if (options && options.cookies) {
@@ -242,7 +249,7 @@ class Provider {
       /**
        * @description Dynamic Registration service.
        */
-      this.DynamicRegistration = new DynamicRegistration(options.dynReg, routes, this.registerPlatform, this.getPlatform, _classPrivateFieldGet(_ENCRYPTIONKEY2, this), this.Database);
+      this.DynamicRegistration = new DynamicRegistration(options.dynReg, routes, this.registerPlatform, this.getPlatform, _classPrivateFieldGet(_ENCRYPTIONKEY2, this), this.Database, _classPrivateFieldGet(_keySize2, this));
     }
     if (options && options.staticPath) _classPrivateFieldGet(_server, this).setStaticPath(options.staticPath);
 
@@ -869,11 +876,12 @@ class Provider {
      * @param {string} [platform.authorizationServer] - Authorization server identifier to be used as the aud when requesting an access token. If not specified, the access token endpoint URL will be used.
      * @returns {Promise<Platform>}
      */
-  async registerPlatform(platform, getPlatform, ENCRYPTIONKEY, Database) {
+  async registerPlatform(platform, getPlatform, ENCRYPTIONKEY, Database, keySize) {
     if (!platform || !platform.url || !platform.clientId) throw new Error('MISSING_PLATFORM_URL_OR_CLIENTID');
     const _Database = Database || this.Database;
     const _ENCRYPTIONKEY = ENCRYPTIONKEY || _classPrivateFieldGet(_ENCRYPTIONKEY2, this);
     const _getPlatform = getPlatform || this.getPlatform;
+    const _keySize = keySize !== undefined ? keySize : _classPrivateFieldGet(_keySize2, this);
     let kid;
     const _platform = await _getPlatform(platform.url, platform.clientId, _ENCRYPTIONKEY, _Database);
     if (!_platform) {
@@ -881,7 +889,7 @@ class Provider {
       if (platform.authConfig.method !== 'RSA_KEY' && platform.authConfig.method !== 'JWK_KEY' && platform.authConfig.method !== 'JWK_SET') throw new Error('INVALID_AUTHCONFIG_METHOD. Details: Valid methods are "RSA_KEY", "JWK_KEY", "JWK_SET".');
       if (!platform.authConfig.key) throw new Error('MISSING_AUTHCONFIG_KEY');
       try {
-        kid = await Auth.generatePlatformKeyPair(_ENCRYPTIONKEY, _Database, platform.url, platform.clientId);
+        kid = await Auth.generatePlatformKeyPair(_ENCRYPTIONKEY, _Database, platform.url, platform.clientId, _keySize);
         const plat = new Platform(platform.name, platform.url, platform.clientId, platform.authenticationEndpoint, platform.accesstokenEndpoint, platform.authorizationServer, kid, _ENCRYPTIONKEY, platform.authConfig, this.Database);
 
         // Save platform to db

--- a/dist/Provider/Services/DynamicRegistration.js
+++ b/dist/Provider/Services/DynamicRegistration.js
@@ -27,9 +27,10 @@ var _getPlatform = /*#__PURE__*/new WeakMap();
 var _registerPlatform = /*#__PURE__*/new WeakMap();
 var _ENCRYPTIONKEY = /*#__PURE__*/new WeakMap();
 var _Database = /*#__PURE__*/new WeakMap();
+var _keySize = /*#__PURE__*/new WeakMap();
 var _DynamicRegistration_brand = /*#__PURE__*/new WeakSet();
 class DynamicRegistration {
-  constructor(options, routes, registerPlatform, getPlatform, ENCRYPTIONKEY, Database) {
+  constructor(options, routes, registerPlatform, getPlatform, ENCRYPTIONKEY, Database, keySize) {
     // Helper method to build URLs
     _classPrivateMethodInitSpec(this, _DynamicRegistration_brand);
     _classPrivateFieldInitSpec(this, _name, void 0);
@@ -47,6 +48,7 @@ class DynamicRegistration {
     _classPrivateFieldInitSpec(this, _registerPlatform, void 0);
     _classPrivateFieldInitSpec(this, _ENCRYPTIONKEY, '');
     _classPrivateFieldInitSpec(this, _Database, void 0);
+    _classPrivateFieldInitSpec(this, _keySize, void 0);
     _classPrivateFieldSet(_name, this, options.name);
     _classPrivateFieldSet(_redirectUris, this, options.redirectUris || []);
     _classPrivateFieldSet(_customParameters, this, options.customParameters || {});
@@ -62,6 +64,7 @@ class DynamicRegistration {
     _classPrivateFieldSet(_registerPlatform, this, registerPlatform);
     _classPrivateFieldSet(_ENCRYPTIONKEY, this, ENCRYPTIONKEY);
     _classPrivateFieldSet(_Database, this, Database);
+    _classPrivateFieldSet(_keySize, this, keySize);
   }
   /**
    * @description Performs dynamic registration flow.
@@ -128,7 +131,7 @@ class DynamicRegistration {
         key: configuration.jwks_uri
       }
     };
-    const registered = await _classPrivateFieldGet(_registerPlatform, this).call(this, platform, _classPrivateFieldGet(_getPlatform, this), _classPrivateFieldGet(_ENCRYPTIONKEY, this), _classPrivateFieldGet(_Database, this));
+    const registered = await _classPrivateFieldGet(_registerPlatform, this).call(this, platform, _classPrivateFieldGet(_getPlatform, this), _classPrivateFieldGet(_ENCRYPTIONKEY, this), _classPrivateFieldGet(_Database, this), _classPrivateFieldGet(_keySize, this));
     await _classPrivateFieldGet(_Database, this).Insert(false, 'platformStatus', {
       id: await registered.platformId(),
       active: _classPrivateFieldGet(_autoActivate, this)

--- a/dist/Utils/Auth.js
+++ b/dist/Utils/Auth.js
@@ -14,9 +14,10 @@ class Auth {
   /**
      * @description Generates a new keypair for a platform.
      * @param {String} ENCRYPTIONKEY - Encryption key.
+     * @param {Number} [keySize = 4096] - RSA modulus length in bits. Must be >= 2048 (LTI 1.3 spec minimum).
      * @returns {String} kid for the keypair.
      */
-  static async generatePlatformKeyPair(ENCRYPTIONKEY, Database, platformUrl, platformClientId) {
+  static async generatePlatformKeyPair(ENCRYPTIONKEY, Database, platformUrl, platformClientId, keySize = 4096) {
     let kid = crypto.randomBytes(16).toString('hex');
     while (await Database.Get(false, 'publickey', {
       kid
@@ -25,7 +26,7 @@ class Auth {
       kid = crypto.randomBytes(16).toString('hex');
     }
     const keys = crypto.generateKeyPairSync('rsa', {
-      modulusLength: 4096,
+      modulusLength: keySize,
       publicKeyEncoding: {
         type: 'spki',
         format: 'pem'

--- a/src/Provider/Provider.js
+++ b/src/Provider/Provider.js
@@ -45,6 +45,8 @@ class Provider {
 
   #tokenMaxAge = 10
 
+  #keySize = 4096
+
   #cookieOptions = {
     secure: false,
     httpOnly: true,
@@ -128,6 +130,7 @@ class Provider {
      * @param {String} [options.cookies.domain] - Cookie domain parameter. This parameter can be used to specify a domain so that the cookies set by Ltijs can be shared between subdomains.
      * @param {Boolean} [options.devMode = false] - If true, does not require state and session cookies to be present (If present, they are still validated). This allows ltijs to work on development environments where cookies cannot be set. THIS SHOULD NOT BE USED IN A PRODUCTION ENVIRONMENT.
      * @param {Number} [options.tokenMaxAge = 10] - Sets the idToken max age allowed in seconds. Defaults to 10 seconds. If false, disables max age validation.
+     * @param {Number} [options.keySize = 4096] - RSA modulus length in bits used by registerPlatform() when generating per-platform keypairs. Must be an integer >= 2048 (LTI 1.3 spec minimum). Lower values reduce the cost of the synchronous keygen call, which on small instances can take 5-30s at the 4096 default; 2048 is the LTI 1.3 spec minimum and matches the modulus length used by Canvas, Moodle, and Blackboard.
      * @param {Object} [options.dynReg] - Setup for the Dynamic Registration Service.
      * @param {String} [options.dynReg.url] - Tool Provider main URL. (Ex: 'https://tool.example.com')
      * @param {String} [options.dynReg.name] - Tool Provider name. (Ex: 'Tool Provider')
@@ -160,6 +163,10 @@ class Provider {
     if (options && options.devMode === true) this.#devMode = true
     if (options && options.ltiaas === true) this.#ltiaas = true
     if (options && options.tokenMaxAge !== undefined) this.#tokenMaxAge = options.tokenMaxAge
+    if (options && options.keySize !== undefined) {
+      if (!Number.isInteger(options.keySize) || options.keySize < 2048) throw new Error('INVALID_KEYSIZE. Details: keySize must be an integer >= 2048 (LTI 1.3 spec minimum).')
+      this.#keySize = options.keySize
+    }
 
     // Cookie options
     if (options && options.cookies) {
@@ -201,7 +208,7 @@ class Provider {
       /**
        * @description Dynamic Registration service.
        */
-      this.DynamicRegistration = new DynamicRegistration(options.dynReg, routes, this.registerPlatform, this.getPlatform, this.#ENCRYPTIONKEY, this.Database)
+      this.DynamicRegistration = new DynamicRegistration(options.dynReg, routes, this.registerPlatform, this.getPlatform, this.#ENCRYPTIONKEY, this.Database, this.#keySize)
     }
 
     if (options && options.staticPath) this.#server.setStaticPath(options.staticPath)
@@ -812,12 +819,13 @@ class Provider {
      * @param {string} [platform.authorizationServer] - Authorization server identifier to be used as the aud when requesting an access token. If not specified, the access token endpoint URL will be used.
      * @returns {Promise<Platform>}
      */
-  async registerPlatform (platform, getPlatform, ENCRYPTIONKEY, Database) {
+  async registerPlatform (platform, getPlatform, ENCRYPTIONKEY, Database, keySize) {
     if (!platform || !platform.url || !platform.clientId) throw new Error('MISSING_PLATFORM_URL_OR_CLIENTID')
 
     const _Database = Database || this.Database
     const _ENCRYPTIONKEY = ENCRYPTIONKEY || this.#ENCRYPTIONKEY
     const _getPlatform = getPlatform || this.getPlatform
+    const _keySize = keySize !== undefined ? keySize : this.#keySize
 
     let kid
     const _platform = await _getPlatform(platform.url, platform.clientId, _ENCRYPTIONKEY, _Database)
@@ -828,7 +836,7 @@ class Provider {
       if (!platform.authConfig.key) throw new Error('MISSING_AUTHCONFIG_KEY')
 
       try {
-        kid = await Auth.generatePlatformKeyPair(_ENCRYPTIONKEY, _Database, platform.url, platform.clientId)
+        kid = await Auth.generatePlatformKeyPair(_ENCRYPTIONKEY, _Database, platform.url, platform.clientId, _keySize)
         const plat = new Platform(platform.name, platform.url, platform.clientId, platform.authenticationEndpoint, platform.accesstokenEndpoint, platform.authorizationServer, kid, _ENCRYPTIONKEY, platform.authConfig, this.Database)
 
         // Save platform to db

--- a/src/Provider/Services/DynamicRegistration.js
+++ b/src/Provider/Services/DynamicRegistration.js
@@ -38,7 +38,9 @@ class DynamicRegistration {
 
   #Database
 
-  constructor (options, routes, registerPlatform, getPlatform, ENCRYPTIONKEY, Database) {
+  #keySize
+
+  constructor (options, routes, registerPlatform, getPlatform, ENCRYPTIONKEY, Database, keySize) {
     this.#name = options.name
     this.#redirectUris = options.redirectUris || []
     this.#customParameters = options.customParameters || {}
@@ -55,6 +57,7 @@ class DynamicRegistration {
 
     this.#ENCRYPTIONKEY = ENCRYPTIONKEY
     this.#Database = Database
+    this.#keySize = keySize
   }
 
   // Helper method to build URLs
@@ -144,7 +147,7 @@ class DynamicRegistration {
         key: configuration.jwks_uri
       }
     }
-    const registered = await this.#registerPlatform(platform, this.#getPlatform, this.#ENCRYPTIONKEY, this.#Database)
+    const registered = await this.#registerPlatform(platform, this.#getPlatform, this.#ENCRYPTIONKEY, this.#Database, this.#keySize)
     await this.#Database.Insert(false, 'platformStatus', { id: await registered.platformId(), active: this.#autoActivate })
 
     // Returing message indicating the end of registration flow

--- a/src/Utils/Auth.js
+++ b/src/Utils/Auth.js
@@ -12,9 +12,10 @@ class Auth {
   /**
      * @description Generates a new keypair for a platform.
      * @param {String} ENCRYPTIONKEY - Encryption key.
+     * @param {Number} [keySize = 4096] - RSA modulus length in bits. Must be >= 2048 (LTI 1.3 spec minimum).
      * @returns {String} kid for the keypair.
      */
-  static async generatePlatformKeyPair (ENCRYPTIONKEY, Database, platformUrl, platformClientId) {
+  static async generatePlatformKeyPair (ENCRYPTIONKEY, Database, platformUrl, platformClientId, keySize = 4096) {
     let kid = crypto.randomBytes(16).toString('hex')
 
     while (await Database.Get(false, 'publickey', { kid })) {
@@ -23,7 +24,7 @@ class Auth {
     }
 
     const keys = crypto.generateKeyPairSync('rsa', {
-      modulusLength: 4096,
+      modulusLength: keySize,
       publicKeyEncoding: {
         type: 'spki',
         format: 'pem'

--- a/test/0-keysize.js
+++ b/test/0-keysize.js
@@ -1,0 +1,56 @@
+// Unit tests for the configurable keySize option on Auth.generatePlatformKeyPair.
+// These exercise the static method directly with an in-memory Database stub so
+// the assertions don't depend on the Provider singleton's setup/deploy lifecycle.
+
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const crypto = require('crypto')
+chai.use(chaiAsPromised)
+const expect = chai.expect
+
+const Auth = require('../dist/Utils/Auth')
+
+// Minimal in-memory Database stand-in. Auth.generatePlatformKeyPair only uses
+// Database.Get (kid uniqueness check) and Database.Replace (key persistence).
+// Pass ENCRYPTIONKEY=false to skip encryption so the stored docs match the
+// pubkeyobj/privkeyobj shape directly.
+function makeStubDatabase () {
+  const store = { publickey: [], privatekey: [] }
+  return {
+    async Get (_ENCRYPTIONKEY, collection, query) {
+      const match = store[collection].find(d =>
+        Object.entries(query).every(([k, v]) => d[k] === v)
+      )
+      return match ? [match] : false
+    },
+    async Replace (_ENCRYPTIONKEY, collection, _query, item) {
+      store[collection].push(item)
+      return true
+    },
+    _store: store
+  }
+}
+
+function modulusLengthOf (pem) {
+  return crypto.createPublicKey(pem).asymmetricKeyDetails.modulusLength
+}
+
+describe('Testing Auth.generatePlatformKeyPair keySize option', function () {
+  this.timeout(20000)
+
+  it('default (no keySize) produces a 4096-bit RSA modulus', async () => {
+    const db = makeStubDatabase()
+    const kid = await Auth.generatePlatformKeyPair(false, db, 'https://platform.example.com', 'cid-default')
+    const pub = db._store.publickey.find(d => d.kid === kid)
+    expect(pub).to.exist
+    expect(modulusLengthOf(pub.key)).to.equal(4096)
+  })
+
+  it('keySize: 2048 produces a 2048-bit RSA modulus', async () => {
+    const db = makeStubDatabase()
+    const kid = await Auth.generatePlatformKeyPair(false, db, 'https://platform.example.com', 'cid-2048', 2048)
+    const pub = db._store.publickey.find(d => d.kid === kid)
+    expect(pub).to.exist
+    expect(modulusLengthOf(pub.key)).to.equal(2048)
+  })
+})

--- a/test/0-provider.js
+++ b/test/0-provider.js
@@ -41,6 +41,18 @@ describe('Testing Provider', function () {
     await expect(lti.deploy({ silent: true })).to.be.rejectedWith(Error)
   })
 
+  // keySize validation runs in setup() before #setup is flipped to true, so
+  // throwing here leaves the singleton in its pre-setup state and the successful
+  // setup test that follows is unaffected.
+  it('Provider.setup expected to throw INVALID_KEYSIZE when keySize is not an integer', () => {
+    const fn = () => lti.setup('LTIKEY', { url: mongoUri }, { keySize: 'not an integer' })
+    expect(fn).to.throw(/INVALID_KEYSIZE/)
+  })
+  it('Provider.setup expected to throw INVALID_KEYSIZE when keySize < 2048', () => {
+    const fn = () => lti.setup('LTIKEY', { url: mongoUri }, { keySize: 1024 })
+    expect(fn).to.throw(/INVALID_KEYSIZE/)
+  })
+
   // Setting up provider
   it('Provider.setup expected to not throw Error', () => {
     const fn = () => {


### PR DESCRIPTION
# configurable platform RSA `modulusLength` via `options.keySize`

Closes https://github.com/Cvmcosta/ltijs/issues/289

## Summary

Adds a new `keySize` option to `lti.setup()` that controls the RSA modulus length used by `Auth.generatePlatformKeyPair` when generating per-platform keypairs during `registerPlatform()`. Default behavior is unchanged (`4096`).

```js
lti.setup(KEY, db, {
  // ...existing options
  keySize: 2048,
})
```

Motivation, benchmarks, and spec context are in the linked issue. The short version: 4096-bit `generateKeyPairSync` is the dominant cost in dynamic registration on small instances (several seconds, with multiplicative variance into the double-digit-seconds range), 2048 is the LTI 1.3 spec minimum, and Canvas/Moodle/Blackboard all use 2048.

## What changed

Threading `keySize` from setup → registerPlatform → Auth, with the same explicit-arg fallback pattern that the existing `ENCRYPTIONKEY`/`Database`/`getPlatform` plumbing uses. This keeps the option working through both call paths:

- **Direct call path** (`lti.registerPlatform({...})`) — `this === Provider`, falls back to the configured `#keySize`.
- **DynamicRegistration path** — `registerPlatform` is invoked as a bare function reference where `this !== Provider`, so the service constructor receives `keySize` from the Provider at setup time and passes it explicitly into the call.

Files touched:

| File | Change |
|------|--------|
| `src/Provider/Provider.js` | New `#keySize = 4096` private field; new `options.keySize` validation in `setup()` (throws `INVALID_KEYSIZE` for non-integer or `< 2048`); JSDoc; `registerPlatform` signature accepts optional `keySize`; passes `this.#keySize` into the `DynamicRegistration` constructor |
| `src/Provider/Services/DynamicRegistration.js` | Constructor accepts `keySize`; stores on a private field; passes it through to `registerPlatform` |
| `src/Utils/Auth.js` | `generatePlatformKeyPair` accepts `keySize = 4096`; uses it for `modulusLength`; JSDoc |
| `test/0-keysize.js` (new) | Unit tests for the static `Auth.generatePlatformKeyPair` with default (4096) and explicit (2048) `keySize` |
| `test/0-provider.js` | Two new tests for `Provider.setup` validation (non-integer and `< 2048` both reject with `INVALID_KEYSIZE`) |

## Backwards compatibility

Default value is unchanged (`4096`). Consumers who do not pass `keySize` see identical behavior. Validation only runs when the option is explicitly set.

## Tests

```
$ npm run build && npm test
...
98 passing (4s)
```

All existing tests pass. New tests:

- `Auth.generatePlatformKeyPair` default produces a 4096-bit RSA modulus
- `Auth.generatePlatformKeyPair` with `keySize: 2048` produces a 2048-bit RSA modulus
- `Provider.setup` rejects non-integer `keySize` with `INVALID_KEYSIZE`
- `Provider.setup` rejects `keySize < 2048` with `INVALID_KEYSIZE`

Modulus length is asserted via `crypto.createPublicKey(pem).asymmetricKeyDetails.modulusLength`.
