### PR TITLE
fix: grade publishing message for student

### DIFF
--- a/dist/Provider/Services/Grade.js
+++ b/dist/Provider/Services/Grade.js
@@ -346,6 +346,7 @@ class Grade {
 
     // Creating timestamp
     score.timestamp = timestamp !== null && timestamp !== void 0 ? timestamp : new Date(Date.now()).toISOString();
+    provGradeServiceDebug('Timestamp provided: ' + timestamp);
     provGradeServiceDebug('Sending score to: ' + scoreUrl);
     provGradeServiceDebug(score);
     await got.post(scoreUrl, {

--- a/dist/Provider/Services/Grade.js
+++ b/dist/Provider/Services/Grade.js
@@ -346,7 +346,11 @@ class Grade {
 
     // Creating timestamp
     score.timestamp = new Date(Date.now()).toISOString();
-    if (timestamp) score.submittedAt = timestamp;
+    if (timestamp) {
+      score.submission = {
+        submittedAt: timestamp
+      };
+    }
     score.comment = "Published from Edugator at " + score.timestamp;
     provGradeServiceDebug('Timestamp provided: ' + timestamp);
     provGradeServiceDebug('Sending score to: ' + scoreUrl);

--- a/dist/Provider/Services/Grade.js
+++ b/dist/Provider/Services/Grade.js
@@ -294,7 +294,7 @@ class Grade {
    * @param {String} lineItemId - LineItem ID.
    * @param {Object} score - Score/Grade following the LTI Standard application/vnd.ims.lis.v1.score+json.
    */
-  async submitScore(idtoken, lineItemId, score) {
+  async submitScore(idtoken, lineItemId, score, timestamp) {
     if (!idtoken) {
       provGradeServiceDebug('Missing IdToken object.');
       throw new Error('MISSING_ID_TOKEN');
@@ -345,7 +345,7 @@ class Grade {
     if (score.userId === undefined) score.userId = idtoken.user;
 
     // Creating timestamp
-    score.timestamp = new Date(Date.now()).toISOString();
+    score.timestamp = new Date(timestamp !== null && timestamp !== void 0 ? timestamp : Date.now()).toISOString();
     provGradeServiceDebug('Sending score to: ' + scoreUrl);
     provGradeServiceDebug(score);
     await got.post(scoreUrl, {

--- a/dist/Provider/Services/Grade.js
+++ b/dist/Provider/Services/Grade.js
@@ -345,7 +345,9 @@ class Grade {
     if (score.userId === undefined) score.userId = idtoken.user;
 
     // Creating timestamp
-    score.timestamp = timestamp !== null && timestamp !== void 0 ? timestamp : new Date(Date.now()).toISOString();
+    score.timestamp = new Date(Date.now()).toISOString();
+    if (timestamp) score.submittedAt = timestamp;
+    score.comment = "Published from Edugator at " + score.timestamp;
     provGradeServiceDebug('Timestamp provided: ' + timestamp);
     provGradeServiceDebug('Sending score to: ' + scoreUrl);
     provGradeServiceDebug(score);

--- a/dist/Provider/Services/Grade.js
+++ b/dist/Provider/Services/Grade.js
@@ -345,7 +345,7 @@ class Grade {
     if (score.userId === undefined) score.userId = idtoken.user;
 
     // Creating timestamp
-    score.timestamp = new Date(timestamp !== null && timestamp !== void 0 ? timestamp : Date.now()).toISOString();
+    score.timestamp = timestamp !== null && timestamp !== void 0 ? timestamp : new Date(Date.now()).toISOString();
     provGradeServiceDebug('Sending score to: ' + scoreUrl);
     provGradeServiceDebug(score);
     await got.post(scoreUrl, {

--- a/dist/Provider/Services/Grade.js
+++ b/dist/Provider/Services/Grade.js
@@ -351,7 +351,7 @@ class Grade {
         submittedAt: timestamp
       };
     }
-    score.comment = "Published from Edugator at " + score.timestamp;
+    score.comment = "Graded by Edugator on " + new Date(score.timestamp).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) + " at " + new Date(score.timestamp).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
     provGradeServiceDebug('Timestamp provided: ' + timestamp);
     provGradeServiceDebug('Sending score to: ' + scoreUrl);
     provGradeServiceDebug(score);

--- a/src/Provider/Services/Grade.js
+++ b/src/Provider/Services/Grade.js
@@ -299,7 +299,11 @@ class Grade {
 
     // Creating timestamp
     score.timestamp = new Date(Date.now()).toISOString()
-    if (timestamp) score.submittedAt = timestamp;
+    if (timestamp) {
+      score.submission = {
+        submittedAt: timestamp,
+      };
+    }
     score.comment = "Published from Edugator at " + score.timestamp;
 
     provGradeServiceDebug('Timestamp provided: ' + timestamp)

--- a/src/Provider/Services/Grade.js
+++ b/src/Provider/Services/Grade.js
@@ -298,7 +298,9 @@ class Grade {
     if (score.userId === undefined) score.userId = idtoken.user
 
     // Creating timestamp
-    score.timestamp = timestamp ?? new Date(Date.now()).toISOString()
+    score.timestamp = new Date(Date.now()).toISOString()
+    if (timestamp) score.submittedAt = timestamp;
+    score.comment = "Published from Edugator at " + score.timestamp;
 
     provGradeServiceDebug('Timestamp provided: ' + timestamp)
     provGradeServiceDebug('Sending score to: ' + scoreUrl)

--- a/src/Provider/Services/Grade.js
+++ b/src/Provider/Services/Grade.js
@@ -253,7 +253,7 @@ class Grade {
    * @param {String} lineItemId - LineItem ID.
    * @param {Object} score - Score/Grade following the LTI Standard application/vnd.ims.lis.v1.score+json.
    */
-  async submitScore (idtoken, lineItemId, score) {
+  async submitScore (idtoken, lineItemId, score, timestamp) {
     if (!idtoken) { provGradeServiceDebug('Missing IdToken object.'); throw new Error('MISSING_ID_TOKEN') }
     if (!lineItemId) { provGradeServiceDebug('Missing lineItemID.'); throw new Error('MISSING_LINEITEM_ID') }
     if (!score) { provGradeServiceDebug('Score object missing.'); throw new Error('MISSING_SCORE') }
@@ -298,7 +298,7 @@ class Grade {
     if (score.userId === undefined) score.userId = idtoken.user
 
     // Creating timestamp
-    score.timestamp = new Date(Date.now()).toISOString()
+    score.timestamp = new Date(timestamp ?? Date.now()).toISOString()
 
     provGradeServiceDebug('Sending score to: ' + scoreUrl)
     provGradeServiceDebug(score)

--- a/src/Provider/Services/Grade.js
+++ b/src/Provider/Services/Grade.js
@@ -300,6 +300,7 @@ class Grade {
     // Creating timestamp
     score.timestamp = timestamp ?? new Date(Date.now()).toISOString()
 
+    provGradeServiceDebug('Timestamp provided: ' + timestamp)
     provGradeServiceDebug('Sending score to: ' + scoreUrl)
     provGradeServiceDebug(score)
 

--- a/src/Provider/Services/Grade.js
+++ b/src/Provider/Services/Grade.js
@@ -298,7 +298,7 @@ class Grade {
     if (score.userId === undefined) score.userId = idtoken.user
 
     // Creating timestamp
-    score.timestamp = new Date(timestamp ?? Date.now()).toISOString()
+    score.timestamp = timestamp ?? new Date(Date.now()).toISOString()
 
     provGradeServiceDebug('Sending score to: ' + scoreUrl)
     provGradeServiceDebug(score)

--- a/src/Provider/Services/Grade.js
+++ b/src/Provider/Services/Grade.js
@@ -304,7 +304,7 @@ class Grade {
         submittedAt: timestamp,
       };
     }
-    score.comment = "Published from Edugator at " + score.timestamp;
+    score.comment = "Graded by Edugator on " + new Date(score.timestamp).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) + " at " + new Date(score.timestamp).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
 
     provGradeServiceDebug('Timestamp provided: ' + timestamp)
     provGradeServiceDebug('Sending score to: ' + scoreUrl)


### PR DESCRIPTION
This pull request updates the `Grade` service to enhance how score submissions are handled, particularly by allowing an optional submission timestamp and improving the information sent with each grade.

**Enhancements to score submission:**

* The `submitScore` method in `Grade.js` now accepts an optional `timestamp` parameter, allowing the caller to specify when the submission was made.
* If a `timestamp` is provided, it is included in the `score.submission.submittedAt` field, and a detailed comment is added to the score object, noting when the grade was processed.